### PR TITLE
Join tournament bug fix

### DIFF
--- a/Gamex.Service/Contract/ITournamentService.cs
+++ b/Gamex.Service/Contract/ITournamentService.cs
@@ -52,7 +52,7 @@
         /// <param name="user">The user joining the tournament.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A task representing the asynchronous operation. The result is true if the user successfully joins the tournament, otherwise false.</returns>
-        Task<bool> JoinTournament(Guid id, ApplicationUser user, CancellationToken cancellationToken = default);
+        Task<(bool, string)> JoinTournament(Guid id, ApplicationUser user, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Joins a tournament for testing purposes.
@@ -60,7 +60,7 @@
         /// <param name="id">The ID of the tournament to join.</param>
         /// <param name="user">The user joining the tournament.</param>
         /// <returns>A task representing the asynchronous operation. The result is true if the user successfully joins the tournament, otherwise false.</returns>
-        Task<bool> JoinTournamentMock(Guid id, ApplicationUser user);
+        Task<(bool, string)> JoinTournamentMock(Guid id, ApplicationUser user);
         /// <summary>
         /// Joins a tournament with a transaction reference
         /// </summary>
@@ -68,8 +68,8 @@
         /// <param name="user">The user joining the tournament</param>
         /// <param name="transactionReference">The transaction reference</param>
         /// <param name="cancellationToken">The cancellation token</param>
-        /// <returns>Returns true if the user successfully joins the tournament, otherwise false</returns>
-        Task<bool> JoinTournamentWithTransactionReference(Guid id, ApplicationUser user, string transactionReference = "", CancellationToken cancellationToken = default);
+        /// <returns>Returns a tuple with a boolean indicating if the user successfully joins the tournament and a string message</returns>
+        Task<(bool, string)> JoinTournamentWithTransactionReference(Guid id, ApplicationUser user, string transactionReference = "", CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updates a tournament.

--- a/Gamex/Controllers/TournamentController.cs
+++ b/Gamex/Controllers/TournamentController.cs
@@ -217,7 +217,7 @@ public class TournamentController(IRepositoryServiceManager repositoryServiceMan
         if (tournamentExist.TournamentUsers.Any(ut => ut.UserId == user.Id))
             return StatusCode(StatusCodes.Status401Unauthorized, new ApiResponse<string>(401, "Your are already in this tournament"));
 
-        if(tournamentExist.AvailableSlot < tournamentExist.TournamentUsers.Count())
+        if (tournamentExist.AvailableSlot < tournamentExist.TournamentUsers.Count())
             return StatusCode(StatusCodes.Status400BadRequest, new ApiResponse<string>(400, "Tournament is full"));
 
         if (tournamentExist.EntryFee > 0)
@@ -234,9 +234,11 @@ public class TournamentController(IRepositoryServiceManager repositoryServiceMan
             }
         }
 
-        await _repositoryServiceManager.TournamentService.JoinTournamentWithTransactionReference(id, user, model?.Reference, cancellationToken);
+        (bool isSuccessful, string message) = await _repositoryServiceManager.TournamentService.JoinTournamentWithTransactionReference(id, user, model?.Reference, cancellationToken);
 
-        return StatusCode(StatusCodes.Status201Created, new ApiResponse<string>("Tournament Successfully Joined"));
+        if (!isSuccessful) return StatusCode(StatusCodes.Status400BadRequest, new ApiResponse<string>(400, message));
+
+        return StatusCode(StatusCodes.Status201Created, new ApiResponse<string>(message));
     }
 
     [HttpGet("featured")]


### PR DESCRIPTION
The most significant changes involve the refactoring of the `JoinTournament`, `JoinTournamentMock`, and `JoinTournamentWithTransactionReference` methods in the `ITournamentService` interface and `TournamentService` class. These methods now return a tuple containing a boolean and a string, instead of just a boolean. The boolean indicates the success of the operation, while the string provides a message about the operation. Additionally, these methods no longer throw exceptions when the tournament is not found or is full, but instead return a tuple with `false` and an appropriate message.

Another important change is in the `TournamentController` class, where the call to `JoinTournamentWithTransactionReference` now checks the returned boolean and returns an appropriate HTTP status code and message.

Lastly, the `creditId` variable in the `JoinTournamentWithTransactionReference` method has been renamed to `debitId`.

List of changes:

1. The return type of the `JoinTournament`, `JoinTournamentMock`, and `JoinTournamentWithTransactionReference` methods in the `ITournamentService` interface and `TournamentService` class have been changed from `Task<bool>` to `Task<(bool, string)>`.
2. The `JoinTournamentMock`, `JoinTournament`, and `JoinTournamentWithTransactionReference` methods in the `TournamentService` class have been refactored to return a tuple with `false` and an appropriate message instead of throwing exceptions when the tournament is not found or is full.
3. The `creditId` variable in the `JoinTournamentWithTransactionReference` method has been renamed to `debitId`.
4. In the `TournamentController` class, the call to `JoinTournamentWithTransactionReference` now checks the returned boolean and returns an appropriate HTTP status code and message.