### PR TITLE
Live

### DIFF
--- a/Gamex.Service/Implementation/LeaderboardService.cs
+++ b/Gamex.Service/Implementation/LeaderboardService.cs
@@ -17,7 +17,7 @@ public class LeaderboardService(GamexDbContext context) : ILeaderboardService
              .Select(g => new LeaderboardDTO
              {
                  PlayerId = g.Key,
-                 PlayerName = g.First().DisplayName,
+                 PlayerName = g.First().DisplayName ?? $"{g.First().FirstName} {g.First().LastName}",
                  PlayerProfilePictureUrl = g.First().Picture != null ? g.First().Picture.FileUrl : "",
                  Tournaments = g.First().UserTournaments.Count,
                  Points = g.First().UserTournaments.Sum(ut => ut.Point ?? 0)

--- a/Gamex/Controllers/AuthController.cs
+++ b/Gamex/Controllers/AuthController.cs
@@ -123,7 +123,7 @@ public class AuthController(IRepositoryServiceManager repo, UserManager<Applicat
         if (userExist is not null)
         {
             // Return a token for the user
-            if (userExist.ExternalAuthInWithGoogle == false)
+            if (userExist.ExternalAuthInWithGoogle)
             {
                 userExist.ExternalAuthInWithGoogle = true;
                 userExist.EmailConfirmed = true;
@@ -141,14 +141,15 @@ public class AuthController(IRepositoryServiceManager repo, UserManager<Applicat
         // Create a new user
         ApplicationUser user = new()
         {
-            Email = response?.Data?.Email,
+            Email = response.Data?.Email,
             EmailConfirmed = true,
-            FirstName = response?.Data?.GivenName ?? string.Empty,
-            LastName = response?.Data?.FamilyName ?? string.Empty,
+            FirstName = response.Data?.GivenName ?? string.Empty,
+            LastName = response.Data?.FamilyName ?? string.Empty,
             SecurityStamp = Guid.NewGuid().ToString(),
-            UserName = response?.Data?.Email,
+            UserName = response.Data?.Email,
             ExternalAuthInWithGoogle = true,
             PictureId = picture.Id,
+            DisplayName = response.Data?.Name,
             //ReceivePushNotification = true
         };
 


### PR DESCRIPTION
The most significant changes involve the refactoring of the `JoinTournament`, `JoinTournamentMock`, and `JoinTournamentWithTransactionReference` methods in the `ITournamentService` interface and `TournamentService` class. These methods now return a tuple containing a boolean and a string, instead of just a boolean. The boolean indicates the success of the operation, while the string provides a message about the operation. Additionally, these methods no longer throw exceptions when the tournament is not found or is full, but instead return a tuple with `false` and an appropriate message.

Another important change is in the `TournamentController` class, where the call to `JoinTournamentWithTransactionReference` now checks the returned boolean and returns an appropriate HTTP status code and message.

Lastly, the `creditId` variable in the `JoinTournamentWithTransactionReference` method has been renamed to `debitId`.

List of changes:

1. The return type of the `JoinTournament`, `JoinTournamentMock`, and `JoinTournamentWithTransactionReference` methods in the `ITournamentService` interface and `TournamentService` class have been changed from `Task<bool>` to `Task<(bool, string)>`.
2. The `JoinTournamentMock`, `JoinTournament`, and `JoinTournamentWithTransactionReference` methods in the `TournamentService` class have been refactored to return a tuple with `false` and an appropriate message instead of throwing exceptions when the tournament is not found or is full.
3. The `creditId` variable in the `JoinTournamentWithTransactionReference` method has been renamed to `debitId`.
4. In the `TournamentController` class, the call to `JoinTournamentWithTransactionReference` now checks the returned boolean and returns an appropriate HTTP status code and message.