### PR TITLE
tag fetch cache bug fix

### DIFF
--- a/Gamex/Controllers/BlogController.cs
+++ b/Gamex/Controllers/BlogController.cs
@@ -268,7 +268,7 @@ public class BlogController(IRepositoryServiceManager repo, UserManager<Applicat
     {
         var cachedTags = await _repositoryServiceManager.CacheService.GetOrCreateAsync(
             $"{nameof(GetTags)}",
-                                    () => Task.FromResult(_repositoryServiceManager.TagService.GetAllTags())
+                                    () => Task.FromResult(_repositoryServiceManager.TagService.GetAllTags().ToList())
                                                     );
         return StatusCode(StatusCodes.Status200OK, new ApiResponse<IEnumerable<TagDTO>>(cachedTags));
     }


### PR DESCRIPTION
The most significant change is in the `BlogController.cs` file where the lambda function passed to the `GetOrCreateAsync` method of the `CacheService` object has been modified. The function now returns a list instead of the result of the `GetAllTags` method of the `TagService` object. This change is crucial for ensuring the returned data is a list, which may be required for subsequent operations or compatibility with the `ApiResponse` object.

List of changes:
- The lambda function in the `GetOrCreateAsync` method of the `CacheService` object in the `BlogController.cs` file has been modified to return a list by calling `ToList` on the result of `GetAllTags` method of the `TagService` object. This change ensures the returned data is a list, which may be necessary for subsequent operations or compatibility with the `ApiResponse` object. (Reference: `BlogController.cs`)