### PR TITLE
Update EF Core models and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,4 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 /GamexAdmin/GamexAdmin/appsettings.Production.json
+/.idea/.idea.Gamex/.idea

--- a/Gamex.Data/GamexDbContext.cs
+++ b/Gamex.Data/GamexDbContext.cs
@@ -104,20 +104,23 @@ public class GamexDbContext(DbContextOptions<GamexDbContext> options) : Identity
             .HasOne(ut => ut.User)
             .WithMany(u => u.UserTournaments)
             .HasForeignKey(ut => ut.UserId)
-            .OnDelete(DeleteBehavior.Cascade); // Changed from NoAction to Cascade
+            .OnDelete(DeleteBehavior.ClientNoAction); // Changed from NoAction to Cascade
 
         builder.Entity<UserTournament>()
             .HasOne(ut => ut.Tournament)
             .WithMany(t => t.UserTournaments)
             .HasForeignKey(ut => ut.TournamentId)
-            .OnDelete(DeleteBehavior.Cascade); // Changed from NoAction to Cascade
+            .OnDelete(DeleteBehavior.ClientNoAction); // Changed from NoAction to Cascade
 
         builder.Entity<UserTournament>()
             .Property(ut => ut.Amount)
             .HasColumnType("decimal(18,2)");
 
         builder.Entity<Tournament>()
-            .HasOne(t => t.Picture);
+            .HasOne(t => t.Picture)
+            .WithMany()
+            .HasForeignKey(t => t.PictureId)
+            .OnDelete(DeleteBehavior.ClientNoAction);
 
         builder.Entity<Tournament>()
             .Property(t => t.EntryFee)
@@ -135,13 +138,13 @@ public class GamexDbContext(DbContextOptions<GamexDbContext> options) : Identity
             .HasOne(c => c.Post)
             .WithMany(p => p.Comments)
             .HasForeignKey(c => c.PostId)
-            .OnDelete(DeleteBehavior.Cascade); // Added new foreign key constraint
+            .OnDelete(DeleteBehavior.ClientNoAction); // Added new foreign key constraint
 
         builder.Entity<Post>()
             .HasOne(p => p.User)
             .WithMany(u => u.Posts)
             .HasForeignKey(p => p.UserId)
-            .OnDelete(DeleteBehavior.NoAction); // Added new foreign key constraint
+            .OnDelete(DeleteBehavior.ClientNoAction); // Added new foreign key constraint
 
         builder.Entity<ApplicationUser>()
             .HasOne(u => u.Picture);
@@ -150,13 +153,13 @@ public class GamexDbContext(DbContextOptions<GamexDbContext> options) : Identity
             .HasOne(pt => pt.User)
             .WithMany(u => u.PaymentTransactions)
             .HasForeignKey(pt => pt.UserId)
-            .OnDelete(DeleteBehavior.Cascade); // Added new foreign key constraint
+            .OnDelete(DeleteBehavior.ClientNoAction); // Added new foreign key constraint
 
         builder.Entity<PaymentTransaction>()
             .HasOne(pt => pt.Tournament)
             .WithMany(t => t.PaymentTransactions)
             .HasForeignKey(pt => pt.TournamentId)
-            .OnDelete(DeleteBehavior.NoAction); // Added new foreign key constraint
+            .OnDelete(DeleteBehavior.ClientNoAction); // Added new foreign key constraint
 
         builder.Entity<PaymentTransaction>()
             .Property(pt => pt.Amount)
@@ -173,48 +176,48 @@ public class GamexDbContext(DbContextOptions<GamexDbContext> options) : Identity
             .HasMany(t => t.PostTags)
             .WithOne(pt => pt.Tag)
             .HasForeignKey(pt => pt.TagId)
-            .OnDelete(DeleteBehavior.NoAction);
+            .OnDelete(DeleteBehavior.ClientNoAction);
 
         builder.Entity<Post>()
             .HasMany(p => p.PostTags)
             .WithOne(pt => pt.Post)
             .HasForeignKey(pt => pt.PostId)
-            .OnDelete(DeleteBehavior.NoAction);
+            .OnDelete(DeleteBehavior.ClientNoAction);
 
         builder.Entity<PostTag>()
             .HasOne(pt => pt.Post)
             .WithMany(p => p.PostTags)
             .HasForeignKey(pt => pt.PostId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.ClientNoAction);
 
         builder.Entity<PostTag>()
             .HasOne(pt => pt.Tag)
             .WithMany(t => t.PostTags)
             .HasForeignKey(pt => pt.TagId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.ClientNoAction);
 
         builder.Entity<TournamentRound>()
             .HasOne(tr => tr.Tournament)
             .WithMany(t => t.TournamentRounds)
             .HasForeignKey(tr => tr.TournamentId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.ClientNoAction);
 
         builder.Entity<Tournament>()
             .HasMany(t => t.TournamentRounds)
             .WithOne(tr => tr.Tournament)
             .HasForeignKey(tr => tr.TournamentId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.ClientNoAction);
 
         builder.Entity<RoundMatch>()
             .HasOne(rm => rm.TournamentRound)
             .WithMany(tr => tr.RoundMatches)
             .HasForeignKey(rm => rm.TournamentRoundId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.ClientNoAction);
 
         builder.Entity<TournamentRound>()
             .HasMany(tr => tr.RoundMatches)
             .WithOne(rm => rm.TournamentRound)
             .HasForeignKey(rm => rm.TournamentRoundId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.ClientNoAction);
     }
 }

--- a/Gamex.Data/Migrations/20240621134017_Delete_behavior.Designer.cs
+++ b/Gamex.Data/Migrations/20240621134017_Delete_behavior.Designer.cs
@@ -4,6 +4,7 @@ using Gamex.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Gamex.Data.Migrations
 {
     [DbContext(typeof(GamexDbContext))]
-    partial class GamexDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240621134017_Delete_behavior")]
+    partial class Delete_behavior
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Gamex.Data/Migrations/20240621134017_Delete_behavior.cs
+++ b/Gamex.Data/Migrations/20240621134017_Delete_behavior.cs
@@ -1,0 +1,202 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Gamex.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Delete_behavior : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Comments_Posts_PostId",
+                table: "Comments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PaymentTransactions_AspNetUsers_UserId",
+                table: "PaymentTransactions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PostTags_Posts_PostId",
+                table: "PostTags");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PostTags_Tags_TagId",
+                table: "PostTags");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RoundMatches_TournamentRounds_TournamentRoundId",
+                table: "RoundMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TournamentRounds_Tournaments_TournamentId",
+                table: "TournamentRounds");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserTournaments_AspNetUsers_UserId",
+                table: "UserTournaments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserTournaments_Tournaments_TournamentId",
+                table: "UserTournaments");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Comments_Posts_PostId",
+                table: "Comments",
+                column: "PostId",
+                principalTable: "Posts",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PaymentTransactions_AspNetUsers_UserId",
+                table: "PaymentTransactions",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PostTags_Posts_PostId",
+                table: "PostTags",
+                column: "PostId",
+                principalTable: "Posts",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PostTags_Tags_TagId",
+                table: "PostTags",
+                column: "TagId",
+                principalTable: "Tags",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RoundMatches_TournamentRounds_TournamentRoundId",
+                table: "RoundMatches",
+                column: "TournamentRoundId",
+                principalTable: "TournamentRounds",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TournamentRounds_Tournaments_TournamentId",
+                table: "TournamentRounds",
+                column: "TournamentId",
+                principalTable: "Tournaments",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserTournaments_AspNetUsers_UserId",
+                table: "UserTournaments",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserTournaments_Tournaments_TournamentId",
+                table: "UserTournaments",
+                column: "TournamentId",
+                principalTable: "Tournaments",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Comments_Posts_PostId",
+                table: "Comments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PaymentTransactions_AspNetUsers_UserId",
+                table: "PaymentTransactions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PostTags_Posts_PostId",
+                table: "PostTags");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PostTags_Tags_TagId",
+                table: "PostTags");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RoundMatches_TournamentRounds_TournamentRoundId",
+                table: "RoundMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TournamentRounds_Tournaments_TournamentId",
+                table: "TournamentRounds");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserTournaments_AspNetUsers_UserId",
+                table: "UserTournaments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserTournaments_Tournaments_TournamentId",
+                table: "UserTournaments");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Comments_Posts_PostId",
+                table: "Comments",
+                column: "PostId",
+                principalTable: "Posts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PaymentTransactions_AspNetUsers_UserId",
+                table: "PaymentTransactions",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PostTags_Posts_PostId",
+                table: "PostTags",
+                column: "PostId",
+                principalTable: "Posts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PostTags_Tags_TagId",
+                table: "PostTags",
+                column: "TagId",
+                principalTable: "Tags",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RoundMatches_TournamentRounds_TournamentRoundId",
+                table: "RoundMatches",
+                column: "TournamentRoundId",
+                principalTable: "TournamentRounds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TournamentRounds_Tournaments_TournamentId",
+                table: "TournamentRounds",
+                column: "TournamentId",
+                principalTable: "Tournaments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserTournaments_AspNetUsers_UserId",
+                table: "UserTournaments",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserTournaments_Tournaments_TournamentId",
+                table: "UserTournaments",
+                column: "TournamentId",
+                principalTable: "Tournaments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
- Updated .gitignore to include new patterns and paths for MigrationBackup/, .ionide/, FodyWeavers.xsd, appsettings.Production.json, and .idea directories.
- Modified delete behavior in GamexDbContext.cs from DeleteBehavior.Cascade to DeleteBehavior.ClientNoAction for multiple entities including UserTournament, Tournament, Comment, Post, ApplicationUser, PaymentTransaction, Tag, PostTag, TournamentRound, and RoundMatch.
- Updated GamexDbContextModelSnapshot.cs to reflect the new delete behavior and adjustments in relationships.
- Added a new migration script (20240621134017_Delete_behavior.cs) to apply changes in delete behavior by dropping and re-adding foreign keys without cascade delete option for Comments, PaymentTransactions, PostTags, RoundMatches, TournamentRounds, and UserTournaments.